### PR TITLE
allowing dots in the s3 bucket name

### DIFF
--- a/templates/cf-origin-verify-sm-only.yaml
+++ b/templates/cf-origin-verify-sm-only.yaml
@@ -66,7 +66,7 @@ Parameters:
     Description: S3 bucket with artifact files (Lambda functions, templates, html files, etc.).
     Type: String
     Default: 
-    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
+    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-.]*[0-9a-zA-Z])*$
     ConstraintDescription: ArtifactsBucket S3 bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-).
       It cannot start or end with a hyphen (-).
   ArtifactsPrefix:


### PR DESCRIPTION
*Issue #, if available:*
s3 bucket url doesn't allow dots

*Description of changes:*
changed regex in cloudformation template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
